### PR TITLE
Add year to MIT license content. Closes #13

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ vscode-generator-code
 
 The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation
+Copyright (c) 2015 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is trivial PR.
The year is standard part of MIT license
and part of MIT license template:
https://tldrlegal.com/license/mit-license\#fulltext
Thanks!