### PR TITLE
Resolving the tsconfig.json validation warning

### DIFF
--- a/generators/app/templates/ext-command-ts/tsconfig.json
+++ b/generators/app/templates/ext-command-ts/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es5",
 		"outDir": "out",
 		"noLib": true,
 		"sourceMap": true


### PR DESCRIPTION
This resolves issue #20. In vscode, there is no specific tsconfig.json contribution for handling the file and instead uses the generic json validator which is case sensitive. The tsconfig.json validation uses the schema defined on schemastore.org which uses lowercase for the target values. The tsc compiler doesn't case about case sensitivity when being called.