### PR TITLE
use ${workspaceRoot} when generating a launch.json

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]


### PR DESCRIPTION
We have made our relative path conversion mechanims stricter such that it now requires a ${workspaceRoot}. This change makes the generated TS extension follow that rule