### PR TITLE
Fixes two bugs in generation of a new language support extension.

### DIFF
--- a/generators/app/templates/ext-language/package.json
+++ b/generators/app/templates/ext-language/package.json
@@ -20,7 +20,7 @@
         "grammars": [{
             "language": <%- JSON.stringify(languageId) %>,
             "scopeName": <%- JSON.stringify(languageScopeName) %>,
-            "path": <%- JSON.stringify("./syntaxes/" + languageId + ".tmLanguage") %>
+            "path": <%- JSON.stringify("./syntaxes/" + languageFileName) %>
         }]
     }
 }


### PR DESCRIPTION
This pull request corrects two issues described below.

Please use [Standard ML.plist](https://raw.githubusercontent.com/textmate/standard-ml.tmbundle/master/Syntaxes/Standard%20ML.plist) for testing.

**1. Steps to reproduce the first scenario:** 

- Save a copy of the file linked above to your disk as StandardML.plist.
- Create a "New Language Support" extension from the locally saved copy.
- Notice that the generated package.json contains:
```
"grammars": [{
   "language": "sml",
   "scopeName": "source.ml",
   "path": "./syntaxes/sml.tmLanguage"
}]
```
- But the `syntaxes` folder contains a file `StandardML.plist` and the file `sml.tmLanguage` does not exist.

![standardml-from-local-file-standardml plist](https://cloud.githubusercontent.com/assets/14280254/18457946/840297f2-7965-11e6-9aff-756b78f1c009.png)

**2. Steps to reproduce the second scenario:**
- Create a "New Language Support" extension.
- When prompted `? URL or file:` provide this link https://raw.githubusercontent.com/textmate/standard-ml.tmbundle/master/Syntaxes/Standard%20ML.plist
- When prompted `? Detected languageId: (ml)` do not accept the default. Input `sml` instead.
- Notice that the generated package.json contains:
```
"grammars": [{
    "language": "sml",
    "scopeName": "source.ml",
    "path": "./syntaxes/sml.tmLanguage"
}]
```
- But the `syntaxes` folder contains a file `ml.tmLanguage` and the file `sml.tmLanguage` does not exist.

![standardml-from-github](https://cloud.githubusercontent.com/assets/14280254/18457924/6bd717d4-7965-11e6-9b0a-1ae83fcb360c.png)

