### PR TITLE
Use `code` markup for `<user home>` in quickstarts

### DIFF
--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -39,5 +39,5 @@ and this useful [blog post](http://www.apeth.com/nonblog/stories/textmatebundle.
   * `guide`: Color of the indentation guides which indicate nesting levels.
 
 ## Install your extension
-* To start using your extension with Visual Studio Code copy it into the <user home>/.vscode/extensions folder and restart Code.
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
 * To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.

--- a/generators/app/templates/ext-language/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-language/vsc-extension-quickstart.md
@@ -23,5 +23,5 @@ comments and brackets.
 https://code.visualstudio.com/docs
 
 ## Install your extension
-* To start using your extension with Visual Studio Code copy it into the <user home>/.vscode/extensions folder and restart Code.
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
 * To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.

--- a/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
@@ -4,7 +4,7 @@
 * This folder contains all of the files necessary for your extension
 * `package.json` - this is the manifest file that defines the location of the snippet file
 and specifies the language of the snippets
-* `snippets/snippets.json` - the file containing all snippets 
+* `snippets/snippets.json` - the file containing all snippets
 
 ## Get up and running straight away
 * press `F5` to open a new window with your extension loaded

--- a/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
@@ -16,5 +16,5 @@ and specifies the language of the snippets
 * you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
 
 ## Install your extension
-* To start using your extension with Visual Studio Code copy it into the <user home>/.vscode/extensions folder and restart Code.
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
 * To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.


### PR DESCRIPTION
With this change, the '<user home>' text is readable in rendered Markdown.

### Before
<img width="531" alt="screenshot 2017-01-13 22 26 40" src="https://cloud.githubusercontent.com/assets/2177366/21952021/74445ef6-d9df-11e6-99c4-14582fac5938.png">

### After
<img width="529" alt="screenshot 2017-01-13 22 26 51" src="https://cloud.githubusercontent.com/assets/2177366/21952022/77748f1a-d9df-11e6-8adf-0d5506494078.png">
