### PR TITLE
Bump vsCodeEngine to 1.10.x

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -1,3 +1,3 @@
 module.exports = {
-    vsCodeEngine: '^1.5.0'
+    vsCodeEngine: '^1.9.1'
 }

--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -1,3 +1,3 @@
 module.exports = {
-    vsCodeEngine: '^1.10'
+    vsCodeEngine: '^1.10.0'
 }

--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -1,3 +1,3 @@
 module.exports = {
-    vsCodeEngine: '^1.9.1'
+    vsCodeEngine: '^1.10'
 }


### PR DESCRIPTION
In order to use `inspect` on the [WorkspaceConfiguration][1] the version needed to be bumped.


[1]: https://code.visualstudio.com/docs/extensionAPI/vscode-api#_a-nameworkspaceconfigurationaspan-classcodeitem-id844workspaceconfigurationspan