### PR TITLE
Fix indentation and code folding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 4
+
+[*.json]
+indent_size = 4

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/generators/app/templates

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,11 @@
+---
+  env:
+    es6: true
+
+  rules:
+    indent:
+      - error
+      - 4
+      - SwitchCase: 1
+        FunctionDeclaration:
+          body: 1

--- a/test/test.js
+++ b/test/test.js
@@ -112,7 +112,7 @@ describe('test code generator', function () {
             }, done);
     });
 
- it('language', function (done) {
+    it('language', function (done) {
         this.timeout(10000);
 
         helpers.run(path.join(__dirname, '../generators/app'))


### PR DESCRIPTION
Bad indentation in `test/test.js` was breaking code folding in my editor, so I fixed that and added both .editorconfig settings _and_ minimal ESlint rules to prevent this from happening again.