### PR TITLE
Typo and formatting nitpicks

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -140,7 +140,7 @@ module.exports = yeoman.Base.extend({
             }
 
             generator.extensionConfig.isCustomization = true;
-            generator.log("Enter the URL (http, https) or the file path of the tmLanguage grammar or press ENTER to start with an new grammar.");
+            generator.log("Enter the URL (http, https) or the file path of the tmLanguage grammar or press ENTER to start with a new grammar.");
             return generator.prompt({
                 type: 'input',
                 name: 'tmLanguageURL',
@@ -165,7 +165,7 @@ module.exports = yeoman.Base.extend({
                 }
                 return Promise.resolve();
             }
-            generator.log("Folder location that contains Text Mate (.tmSnippet) and Sublime snippets (.sublime-snippet) or press ENTER to start with an new snippet file.");
+            generator.log("Folder location that contains Text Mate (.tmSnippet) and Sublime snippets (.sublime-snippet) or press ENTER to start with a new snippet file.");
 
             var snippetPrompt = function() {
                 return generator.prompt({
@@ -373,7 +373,7 @@ module.exports = yeoman.Base.extend({
                 return Promise.resolve();
             }
 
-            generator.log('Enter the name of the language. The name will be shown in the VS code editor mode selector.');
+            generator.log('Enter the name of the language. The name will be shown in the VS Code editor mode selector.');
             return generator.prompt({
                 type: 'input',
                 name: 'languageName',

--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -1,19 +1,19 @@
 # Welcome to your VS Code Extension
 
 ## What's in the folder
-* This folder contains all of the files necessary for your color theme extension
-* `package.json` - this is the manifest file that defines the location of the theme file
-and specifies the base theme of the theme
-* `themes/<%= themeFileName %>` - the color theme definition file
+* This folder contains all of the files necessary for your color theme extension.
+* `package.json` - this is the manifest file that defines the location of the theme file.
+and specifies the base theme of the theme.
+* `themes/<%= themeFileName %>` - the color theme definition file.
 
 ## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* open `File > Preferences > Color Themes` and pick your color theme
+* Press `F5` to open a new window with your extension loaded.
+* Open `File > Preferences > Color Themes` and pick your color theme.
 * Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Inspect TM Scopes` command from the Commmand Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) .
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after making changes to the files listed above
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 * When editing workbench colors, it's easiest to test the colors in the settings under `workbench.colorCustomizations` and `workbench.tokenColorCustomizations`. When done, run the `Generate Color Theme From Current Settings` command to generate an updated content for the color theme definition file.
 
 ## Adopt your theme to Visual Studio Code

--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -18,7 +18,7 @@ and specifies the base theme of the theme
 
 ## Adopt your theme to Visual Studio Code
 * The token colorization is done based on standard TextMate themes. Colors are matched against one or more scopes.
-To learn more about what scopes and scope se, check out the [theme](https://code.visualstudio.com/docs/extensions/themes-snippets-colorizers#_adding-a-new-color-theme) documentation.
+To learn more about scopes and how they're used, check out the [theme](https://code.visualstudio.com/docs/extensions/themes-snippets-colorizers#_adding-a-new-color-theme) documentation.
 
 ## Install your extension
 * To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.

--- a/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
@@ -1,7 +1,7 @@
-# Welcome to your first VS Code Extension
+# Welcome to your VS Code Extension
 
 ## What's in the folder
-* This folder contains all of the files necessary for your extension
+* This folder contains all of the files necessary for your extension.
 * `package.json` - this is the manifest file in which you declare your extension and command.
 The sample plugin registers a command and defines its title and command name. With this information
 VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
@@ -12,22 +12,22 @@ We pass the function containing the implementation of the command as the second 
 `registerCommand`.
 
 ## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`
-* set breakpoints in your code inside extension.js to debug your extension
-* find output from your extension in the debug console
+* Press `F5` to open a new window with your extension loaded.
+* Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
+* Set breakpoints in your code inside `extension.js` to debug your extension.
+* Find output from your extension in the debug console.
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after changing code in `extension.js`
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after changing code in `extension.js`.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
 ## Explore the API
-* you can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`
+* You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
 
 ## Run tests
-* open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`
-* press `F5` to run the tests in a new window with your extension loaded
-* see the output of the test result in the debug console
-* make changes to `test/extension.test.js` or create new test files inside the `test` folder
-    * by convention, the test runner will only consider files matching the name pattern `**.test.js`
-    * you can create folders inside the `test` folder to structure your tests any way you want
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`.
+* Press `F5` to run the tests in a new window with your extension loaded.
+* See the output of the test result in the debug console.
+* Make changes to `test/extension.test.js` or create new test files inside the `test` folder.
+    * By convention, the test runner will only consider files matching the name pattern `**.test.js`.
+    * You can create folders inside the `test` folder to structure your tests any way you want.

--- a/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
@@ -1,7 +1,7 @@
-# Welcome to your first VS Code Extension
+# Welcome to your VS Code Extension
 
 ## What's in the folder
-* This folder contains all of the files necessary for your extension
+* This folder contains all of the files necessary for your extension.
 * `package.json` - this is the manifest file in which you declare your extension and command.
 The sample plugin registers a command and defines its title and command name. With this information
 VS Code can show the command in the command palette. It doesn’t yet need to load the plugin.
@@ -12,22 +12,22 @@ We pass the function containing the implementation of the command as the second 
 `registerCommand`.
 
 ## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`
-* set breakpoints in your code inside `src/extension.ts` to debug your extension
-* find output from your extension in the debug console
+* Press `F5` to open a new window with your extension loaded.
+* Run your command from the command palette by pressing (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and typing `Hello World`.
+* Set breakpoints in your code inside `src/extension.ts` to debug your extension.
+* Find output from your extension in the debug console.
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
 ## Explore the API
-* you can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`
+* You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
 
 ## Run tests
-* open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`
-* press `F5` to run the tests in a new window with your extension loaded
-* see the output of the test result in the debug console
-* make changes to `test/extension.test.ts` or create new test files inside the `test` folder
-    * by convention, the test runner will only consider files matching the name pattern `**.test.ts`
-    * you can create folders inside the `test` folder to structure your tests any way you want
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`.
+* Press `F5` to run the tests in a new window with your extension loaded.
+* See the output of the test result in the debug console.
+* Make changes to `test/extension.test.ts` or create new test files inside the `test` folder.
+    * By convention, the test runner will only consider files matching the name pattern `**.test.ts`.
+    * You can create folders inside the `test` folder to structure your tests any way you want.

--- a/generators/app/templates/ext-extensionpack/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-extensionpack/vsc-extension-quickstart.md
@@ -1,16 +1,16 @@
 # Welcome to your VS Code Extension Pack
 
 ## What's in the folder
-* This folder contains all of the files necessary for your extension pack
-* `package.json` - this is the manifest file that defines the list of extensions of the extension pack
+* This folder contains all of the files necessary for your extension pack.
+* `package.json` - this is the manifest file that defines the list of extensions of the extension pack.
 
 ## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* open `Extensions Viewlet` and check your extensions are installed
+* Press `F5` to open a new window with your extension loaded.
+* Open `Extensions Viewlet` and check your extensions are installed.
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after making changes to the files listed above
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
 ## Install your extension
 * To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.

--- a/generators/app/templates/ext-language/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-language/vsc-extension-quickstart.md
@@ -1,22 +1,22 @@
 # Welcome to your VS Code Extension
 
 ## What's in the folder
-* This folder contains all of the files necessary for your extension
+* This folder contains all of the files necessary for your extension.
 * `package.json` - this is the manifest file in which you declare your language support and define
 the location of the grammar file that has been copied into your extension.
-* `syntaxes/<%= languageFileName %>` - this is the Text mate grammar file that is used for tokenization
+* `syntaxes/<%= languageFileName %>` - this is the Text mate grammar file that is used for tokenization.
 * `language-configuration.json` - this the language configuration, defining the tokens that are used for
 comments and brackets.
 
 ## Get up and running straight away
-* Make sure the language configuration settings in `language-configuration.json` are accurate
-* press `F5` to open a new window with your extension loaded
-* create a new file with a file name suffix matching your language
-* verify that syntax highlighting works and that the language configuration settings are working
+* Make sure the language configuration settings in `language-configuration.json` are accurate.
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that syntax highlighting works and that the language configuration settings are working.
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after making changes to the files listed above
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
 ## Add more language features
 * To add features such as intellisense, hovers and validators check out the VS Code extenders documentation at

--- a/generators/app/templates/ext-language/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-language/vsc-extension-quickstart.md
@@ -3,7 +3,7 @@
 ## What's in the folder
 * This folder contains all of the files necessary for your extension
 * `package.json` - this is the manifest file in which you declare your language support and define
-the location of the grammar file that has been copied into you extension.
+the location of the grammar file that has been copied into your extension.
 * `syntaxes/<%= languageFileName %>` - this is the Text mate grammar file that is used for tokenization
 * `language-configuration.json` - this the language configuration, defining the tokens that are used for
 comments and brackets.
@@ -12,7 +12,7 @@ comments and brackets.
 * Make sure the language configuration settings in `language-configuration.json` are accurate
 * press `F5` to open a new window with your extension loaded
 * create a new file with a file name suffix matching your language
-* verify that syntax highlight works and that the language configuration settings are working
+* verify that syntax highlighting works and that the language configuration settings are working
 
 ## Make changes
 * you can relaunch the extension from the debug toolbar after making changes to the files listed above

--- a/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
@@ -1,19 +1,19 @@
 # Welcome to your VS Code Extension
 
 ## What's in the folder
-* This folder contains all of the files necessary for your extension
+* This folder contains all of the files necessary for your extension.
 * `package.json` - this is the manifest file that defines the location of the snippet file
-and specifies the language of the snippets
-* `snippets/snippets.json` - the file containing all snippets
+and specifies the language of the snippets.
+* `snippets/snippets.json` - the file containing all snippets.
 
 ## Get up and running straight away
-* press `F5` to open a new window with your extension loaded
-* create a new file with a file name suffix matching your language
-* verify that your snippets are proposed on intellisense
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that your snippets are proposed on intellisense.
 
 ## Make changes
-* you can relaunch the extension from the debug toolbar after making changes to the files listed above
-* you can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
 ## Install your extension
 * To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.


### PR DESCRIPTION
Firstly, great work on the generator; it was really useful for converting a Sublime Text package over to VS Code.

This PR fixes some minor things that I noticed while using the generator. It has two main parts:

1. Typos and grammatical nitpicks.
2. Consistent capitalisation and punctuation in the bullet points of the various `vsc-extension-quickstart.md` files. The bullet points had a mixture of upper- and lower-case starting letters, and inconsistent application of full stops (periods).

I realise the second part is perhaps overly pedantic. If you’d rather accept just the typo fixes without the reformatting, I’m happy to redo the PR to suit (that’s why they’re separate commits 😉).