### PR TITLE
Fixing 'no such file or directory' error when using `workspaceFolder`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,9 @@
             "type": "node",
             "request": "launch",
             "name": "yeoman code",
-            "program": "${workspaceFolder}/node_modules/yo/lib/cli.js",
+            "program": "${workspaceRoot}/node_modules/yo/lib/cli.js",
             "args": [ "code" ],
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceRoot}",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },
@@ -23,14 +23,14 @@
             "type": "node",
             "request": "launch",
             "name": "Mocha Tests",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
             "args": [
                 "-u",
                 "tdd",
                 "--timeout",
                 "999999",
                 "--colors",
-                "${workspaceFolder}/test"
+                "${workspaceRoot}/test"
             ],
             "internalConsoleOptions": "openOnSessionStart"
         }

--- a/generators/app/templates/ext-colortheme/vscode/launch.json
+++ b/generators/app/templates/ext-colortheme/vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ]
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
         }
     ]
 }

--- a/generators/app/templates/ext-command-js/vscode/launch.json
+++ b/generators/app/templates/ext-command-js/vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false
         },
         {
@@ -15,7 +15,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--extensionTestsPath=${workspaceFolder}/test" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
             "stopOnEntry": false
         }
     ]

--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -7,10 +7,10 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceFolder}/out/src/**/*.js" ],
+            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
             "preLaunchTask": "npm: watch"
         },
         {
@@ -18,10 +18,10 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--extensionTestsPath=${workspaceFolder}/out/test" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceFolder}/out/test/**/*.js" ],
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
             "preLaunchTask": "npm: watch"
         }
     ]

--- a/generators/app/templates/ext-extensionpack/vscode/launch.json
+++ b/generators/app/templates/ext-extensionpack/vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ]
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
         }
     ]
 }

--- a/generators/app/templates/ext-language/vscode/launch.json
+++ b/generators/app/templates/ext-language/vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ]
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
         }
     ]
 }

--- a/generators/app/templates/ext-snippets/vscode/launch.json
+++ b/generators/app/templates/ext-snippets/vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ]
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
         }
     ]
 }


### PR DESCRIPTION
Loading the extension created by the `yo code` command results in the following error:
```
[${workspaceFolder}]: Error: ENOENT: no such file or directory, scandir '${workspaceFolder}'
```
This happens because the `workspaceFolder` environment variable used in the multiple instances of launch.json does not exist (no longer exists?). The [documentation][1] suggests that `workspaceRoot` variable is what should be used. This commit switches all instances of `workspaceFolder` to `workspaceRoot` to fix issue #88.

[1]: https://code.visualstudio.com/docs/editor/tasks#_variable-substitution