### PR TITLE
Update gitignore to include `.vscode-test`

### DIFF
--- a/generators/app/templates/ext-command-js/gitignore
+++ b/generators/app/templates/ext-command-js/gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode-test/

--- a/generators/app/templates/ext-command-ts/gitignore
+++ b/generators/app/templates/ext-command-ts/gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+.vscode-test/


### PR DESCRIPTION
When running `npm test` on a newly generated project, VS Code gets downloaded and stored in the directory `.vscode-test` which is currently *NOT* included in the generated `.gitignore`.

This fix updates the `gitignore` for both JavaScript and TypeScript templates to ignore `.vscode-test`.