### PR TITLE
Update quickstart docs with new name for launching tests

### DIFF
--- a/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
@@ -25,7 +25,7 @@ We pass the function containing the implementation of the command as the second 
 * You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
 
 ## Run tests
-* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`.
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
 * Press `F5` to run the tests in a new window with your extension loaded.
 * See the output of the test result in the debug console.
 * Make changes to `test/extension.test.js` or create new test files inside the `test` folder.

--- a/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
@@ -25,7 +25,7 @@ We pass the function containing the implementation of the command as the second 
 * You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
 
 ## Run tests
-* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Launch Tests`.
+* Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
 * Press `F5` to run the tests in a new window with your extension loaded.
 * See the output of the test result in the debug console.
 * Make changes to `test/extension.test.ts` or create new test files inside the `test` folder.


### PR DESCRIPTION
While going through the quickstart, I noticed the name of the launch configuration for running tests didn't match the documentation.  So, this PR updates the documentation to match!

![image](https://user-images.githubusercontent.com/2986349/46743527-45dbb000-cc77-11e8-81f1-cc9e66893d3d.png)
