### PR TITLE
Improve the vscodeignore for js and ts command extensions

### DIFF
--- a/generators/app/templates/ext-command-js/vscodeignore
+++ b/generators/app/templates/ext-command-js/vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 test/**
 .gitignore
-jsconfig.json
 vsc-extension-quickstart.md
-.eslintrc.json
+**/jsconfig.json
+**/*.map
+**/.eslintrc.json

--- a/generators/app/templates/ext-command-ts/vscodeignore
+++ b/generators/app/templates/ext-command-ts/vscodeignore
@@ -1,9 +1,10 @@
 .vscode/**
 .vscode-test/**
 out/test/**
-out/**/*.map
 src/**
 .gitignore
-tsconfig.json
 vsc-extension-quickstart.md
-tslint.json
+**/tsconfig.json
+**/tslint.json
+**/*.map
+**/*.ts


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/62687

Exclude all `.map` and `.ts` files along with all a more agressive match for some of the config files such as `tsconfig.json`