### PR TITLE
Enable CI with Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,12 @@
+pool:
+  vmImage: 'ubuntu-16.04'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '8.x'
+  displayName: 'Install Node.js 8.x'
+
+- script: |
+    npm ci
+  displayName: 'Install and test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "8"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Yo Code - Extension and Customization Generator
-[![build status](https://travis-ci.org/Microsoft/vscode-generator-code.svg?branch=master)](https://travis-ci.org/Microsoft/vscode-generator-code)
+
+[![Build Status](https://dev.azure.com/ms/vscode-generator-code/_apis/build/status/Microsoft.vscode-generator-code)](https://dev.azure.com/ms/vscode-generator-code/_build/latest?definitionId=17)
 
 We have written a Yeoman generator to help get you started. We plan to add templates for most extension/customization types into this.
 


### PR DESCRIPTION
* Add `azure-pipelines.yml`
* Add Azure Pipelines build badge to the README
* Drop .travis.yml and Travis build badge

Build status:
[![Build Status](https://dev.azure.com/ms/vscode-generator-code/_apis/build/status/Microsoft.vscode-generator-code)](https://dev.azure.com/ms/vscode-generator-code/_build/latest?definitionId=17)

This pipeline is hosted in the Microsoft-shared https://dev.azure.com/ms org. Once you are ready to merge this PR, I can transfer the project to you and update the pipeline's configuration to pull from Microsoft/vscode-generator-code (and not my fork :)).

Will Smythe