### PR TITLE
markdownlint(MD022) Fix

### DIFF
--- a/generators/app/templates/ext-command-js/CHANGELOG.md
+++ b/generators/app/templates/ext-command-js/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release


### PR DESCRIPTION
Problem: markdownlint(MD022) Headings should be surrounded by blank lines
Fix: Add blank line after each heading