### PR TITLE
fix markdownlint(MD022) violation

### DIFF
--- a/generators/app/templates/ext-colortheme/CHANGELOG.md
+++ b/generators/app/templates/ext-colortheme/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-command-js/CHANGELOG.md
+++ b/generators/app/templates/ext-command-js/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-command-ts/CHANGELOG.md
+++ b/generators/app/templates/ext-command-ts/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-extensionpack/CHANGELOG.md
+++ b/generators/app/templates/ext-extensionpack/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension pack will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-keymap/CHANGELOG.md
+++ b/generators/app/templates/ext-keymap/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-language/CHANGELOG.md
+++ b/generators/app/templates/ext-language/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-localization/CHANGELOG.md
+++ b/generators/app/templates/ext-localization/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" language pack will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release

--- a/generators/app/templates/ext-snippets/CHANGELOG.md
+++ b/generators/app/templates/ext-snippets/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
+
 All notable changes to the "<%= name %>" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+
 - Initial release


### PR DESCRIPTION
Problem: markdownlint(MD022) Headings should be surrounded by blank lines
Fix: Add blank line after each heading