### PR TITLE
Update quickstart page for ext-command-ts template

### DIFF
--- a/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
@@ -21,16 +21,12 @@
 * You can relaunch the extension from the debug toolbar after changing code in `src/extension.ts`.
 * You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
-## Explore the API
-
-* You can open the full set of our API when you open the file `node_modules/vscode/vscode.d.ts`.
-
 ## Run tests
 
 * Open the debug viewlet (`Ctrl+Shift+D` or `Cmd+Shift+D` on Mac) and from the launch configuration dropdown pick `Extension Tests`.
 * Press `F5` to run the tests in a new window with your extension loaded.
 * See the output of the test result in the debug console.
-* Make changes to `test/extension.test.ts` or create new test files inside the `test` folder.
+* Make changes to `test/suite/extension.test.ts` or create new test files inside the `test` folder.
   * By convention, the test runner will only consider files matching the name pattern `**.test.ts`.
   * You can create folders inside the `test` folder to structure your tests any way you want.
 


### PR DESCRIPTION
Update quickstart page for ext-command-ts template
- deleted `Explore the API` section as the `vscode.d.ts` is no longer shipped within the vscode npm module
- updated test script path in `Run tests` section from `test/extension.test.ts` to `src/test/suite/extension.test.ts`
