### PR TITLE
Make this generator work with require.resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/vscode-generator-code/issues"
   },
+  "main": "./generators/app/index.js",
   "homepage": "http://code.visualstudio.com",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
I followed [Integrating Yeoman](https://yeoman.io/authoring/integrating-yeoman.html) to learn how to run a generator programatically and noticed the code example there doesn't work with the VS Code generator. See yeoman/environment#116.

I worked around this by using `path.join(__dirname, 'node_modules/generator-code/generators/app/index.js')`, but I think there is no harm down in making this compatible with the guide.

I believe this should do it.