### PR TITLE
stop generating the "runtimeExecutable" property for debug configs

### DIFF
--- a/generators/app/templates/ext-colortheme/vscode/launch.json
+++ b/generators/app/templates/ext-colortheme/vscode/launch.json
@@ -9,7 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]

--- a/generators/app/templates/ext-command-js/vscode/launch.json
+++ b/generators/app/templates/ext-command-js/vscode/launch.json
@@ -9,7 +9,6 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
-			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			]
@@ -18,7 +17,6 @@
 			"name": "Extension Tests",
 			"type": "extensionHost",
 			"request": "launch",
-			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/test/suite/index"

--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -9,7 +9,6 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
-			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
@@ -22,7 +21,6 @@
 			"name": "Extension Tests",
 			"type": "extensionHost",
 			"request": "launch",
-			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"

--- a/generators/app/templates/ext-extensionpack/vscode/launch.json
+++ b/generators/app/templates/ext-extensionpack/vscode/launch.json
@@ -9,7 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]

--- a/generators/app/templates/ext-keymap/vscode/launch.json
+++ b/generators/app/templates/ext-keymap/vscode/launch.json
@@ -9,7 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]

--- a/generators/app/templates/ext-language/vscode/launch.json
+++ b/generators/app/templates/ext-language/vscode/launch.json
@@ -9,7 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]

--- a/generators/app/templates/ext-notebook-renderer/vscode/launch.json
+++ b/generators/app/templates/ext-notebook-renderer/vscode/launch.json
@@ -9,7 +9,6 @@
       "name": "Run Extension",
       "type": "pwa-extensionHost",
       "request": "launch",
-      "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
@@ -26,7 +25,6 @@
       "name": "Run Extension (no server)",
       "type": "extensionHost",
       "request": "launch",
-      "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
@@ -40,7 +38,6 @@
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",
-      "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"

--- a/generators/app/templates/ext-snippets/vscode/launch.json
+++ b/generators/app/templates/ext-snippets/vscode/launch.json
@@ -9,7 +9,6 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
-            "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]


### PR DESCRIPTION
For more than a year VS Code's extension debugging does not use the "runtimeExecutable" property of debug configurations.
This PR removes the "runtimeExecutable" from the templates used by the generator.