### PR TITLE
Replace deprecated `assert.equal` with `strictEqual`

### DIFF
--- a/generators/app/templates/ext-command-js/test/suite/extension.test.js
+++ b/generators/app/templates/ext-command-js/test/suite/extension.test.js
@@ -9,7 +9,7 @@ suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
 });

--- a/generators/app/templates/ext-command-ts/src/test/suite/extension.test.ts
+++ b/generators/app/templates/ext-command-ts/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
 });

--- a/generators/app/templates/ext-command-web/src/test/suite/extension.test.ts
+++ b/generators/app/templates/ext-command-web/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
 	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
 	});
 });

--- a/generators/app/templates/ext-notebook-renderer/src/test/suite/extension.test.ts
+++ b/generators/app/templates/ext-notebook-renderer/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ suite('Extension Test Suite', () => {
   vscode.window.showInformationMessage('Start all tests.');
 
   test('Sample test', () => {
-    assert.equal(-1, [1, 2, 3].indexOf(5));
-    assert.equal(-1, [1, 2, 3].indexOf(0));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
+    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -316,8 +316,8 @@ describe('test code generator', function () {
 
                     actual = JSON.parse(body);
 
-                    assert.equal(actual.name, "Funky");
-                    assert.equal(actual.colors['editor.background'], "#f5f5f5");
+                    assert.strictEqual(actual.name, "Funky");
+                    assert.strictEqual(actual.colors['editor.background'], "#f5f5f5");
                     done();
                 } catch (e) {
                     done(e);
@@ -487,8 +487,8 @@ describe('test code generator', function () {
                     var grammar = fs.readFileSync('syntaxes/crusty.tmLanguage.json', 'utf8');
 
                     var actualGrammar = JSON.parse(grammar);
-                    assert.equal("Crusty", actualGrammar.name);
-                    assert.equal("source.crusty", actualGrammar.scopeName);
+                    assert.strictEqual("Crusty", actualGrammar.name);
+                    assert.strictEqual("source.crusty", actualGrammar.scopeName);
 
                     done();
                 } catch (e) {


### PR DESCRIPTION
`assert.equal` is deperecated in favour of `assert.strictEqual`. See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/51511d064c43b9beee70130b45cb9ae0e453eeb9/types/node/assert.d.ts#L58
