### PR TITLE
Add GUI to pick a test suite files and Test Coverage NYC runner

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -41,6 +41,7 @@ module.exports.getDependencyVersions = async function () {
         "eslint": "^7.9.0",
         "glob": "^7.1.6",
         "mocha": "^8.1.3",
+        "nyc": "^15.1.0",
         "typescript": "^4.0.2",
         "vscode-test": "^1.4.0",
         "@types/webpack-env": "^1.15.2",
@@ -57,4 +58,3 @@ module.exports.getDependencyVersions = async function () {
         "webpack-dev-server": "^3.11.0"
     }
 }
-

--- a/generators/app/templates/ext-command-js/gitignore
+++ b/generators/app/templates/ext-command-js/gitignore
@@ -1,3 +1,5 @@
 node_modules
+coverage/
+.nyc_output/
 .vscode-test/
 *.vsix

--- a/generators/app/templates/ext-command-js/package.json
+++ b/generators/app/templates/ext-command-js/package.json
@@ -33,6 +33,7 @@
         <%- dep("eslint") %>,
         <%- dep("glob") %>,
         <%- dep("mocha") %>,
+        <%- dep("nyc") %>,
         <%- dep("typescript") %>,
         <%- dep("vscode-test") %>
     }

--- a/generators/app/templates/ext-command-js/test/suite/nyc-coverage-test-runner.js
+++ b/generators/app/templates/ext-command-js/test/suite/nyc-coverage-test-runner.js
@@ -1,0 +1,112 @@
+const path = require('path');
+const Mocha = require('mocha');
+const glob = require('glob');
+const vscode = require('vscode');
+
+// Based on
+// - https://github.com/microsoft/vscode-docs/issues/1096#issuecomment-543850032
+// - https://github.com/microsoft/vscode-js-debug/blob/master/src/test/testRunner.ts
+// - https://gitlab.com/gitlab-org/gitlab-vscode-extension/-/issues/224
+
+// !!!
+// !!! Coverage report will be empty with `*` as one of the `activationEvents` in `package.json`.
+// !!!
+
+function setupCoverage() {
+	const NYC = require('nyc');
+	const nyc = new NYC({
+		cwd: path.join(__dirname, '..', '..'),
+		exclude: ['**/test/**', '.vscode-test/**'],
+		reporter: ['text', 'html'],
+		all: true,
+		instrument: true,
+		hookRequire: true,
+		hookRunInContext: true,
+		hookRunInThisContext: true,
+	});
+
+	nyc.reset();
+	nyc.wrap();
+
+	return nyc;
+}
+
+async function run() {
+	// Create the mocha test
+	const mocha = new Mocha({
+		ui: 'tdd',
+		color: true
+	});
+
+	const testsRoot = path.resolve(__dirname, '..');
+	const nyc = process.env.COVERAGE === '1' ? setupCoverage() : null;
+	const files = glob.sync('**/**.test.js', { cwd: testsRoot });
+
+	console.error(`       process.env.COVERAGE: [${process.env.COVERAGE}]`);
+	console.error(`   process.env.SELECT_SUITE: [${process.env.SELECT_SUITE}]`);
+	console.error(`process.env.CUR_OPENED_FILE: [${process.env.CUR_OPENED_FILE}]`);
+	console.error(`                  testsRoot: [${testsRoot}]`);
+
+	let suites = [];
+
+	if (process.env.SELECT_SUITE === '1') {
+		let curOpenedFile = process.env.CUR_OPENED_FILE;
+		if (curOpenedFile && !curOpenedFile.endsWith('.test')) {
+			curOpenedFile = curOpenedFile + '.test';
+		}
+
+		console.error('Suites:');
+
+		const items = files.map(file => {
+			console.error('  - ' + file);
+
+			const item = {
+				label: file,
+				picked: curOpenedFile ? file.includes(curOpenedFile) : false
+			};
+
+			return item;
+		});
+
+		const selected = await vscode.window.showQuickPick(items, {
+			canPickMany: true,
+			ignoreFocusOut: true,
+			placeHolder: 'Pick a one or more test suites to run'
+		});
+
+		if (selected) {
+			suites = selected.map(item => item.label);
+		} else {
+			suites = [];
+		}
+
+	} else {
+		suites = files;
+	}
+
+	console.error('Selected:');
+
+	for (const file of suites) {
+		console.error('  - ' + file);
+		mocha.addFile(path.resolve(testsRoot, file));
+	}
+
+	try {
+		await new Promise((resolve, reject) => {
+			mocha.run(failures =>
+				failures ? reject(new Error(`${failures} tests failed`)) : resolve(),
+			);
+		});
+	} catch (err) {
+		console.error(err);
+	} finally {
+		if (nyc) {
+			nyc.writeCoverageFile();
+			await nyc.report();
+		}
+	}
+}
+
+module.exports = {
+	run
+};

--- a/generators/app/templates/ext-command-js/vscode/launch.json
+++ b/generators/app/templates/ext-command-js/vscode/launch.json
@@ -37,6 +37,22 @@
 				"SELECT_SUITE": "1",
 				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
 			}
+		},
+		{
+			"name": "Extension Tests (Coverage)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/test/suite/nyc-coverage-test-runner"
+			],
+			"preLaunchTask": "npm: pretest",
+			"env": {
+				"COVERAGE": "1",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-js/vscode/launch.json
+++ b/generators/app/templates/ext-command-js/vscode/launch.json
@@ -21,6 +21,22 @@
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/test/suite/index"
 			]
+		},
+		{
+			"name": "Extension Tests (Select)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/test/suite/nyc-coverage-test-runner"
+			],
+			"preLaunchTask": "npm: pretest",
+			"env": {
+				"COVERAGE": "0",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-js/vscode/tasks.json
+++ b/generators/app/templates/ext-command-js/vscode/tasks.json
@@ -1,0 +1,21 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "pretest",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: pretest",
+			"detail": "tsc -p ./",
+			"presentation": {
+				"reveal": "silent",
+				"panel": "shared",
+				"showReuseMessage": false,
+				"clear": true
+			}
+		}
+	]
+}

--- a/generators/app/templates/ext-command-js/vscodeignore
+++ b/generators/app/templates/ext-command-js/vscodeignore
@@ -1,5 +1,7 @@
 .vscode/**
 .vscode-test/**
+.nyc_output/**
+coverage/**
 test/**
 .gitignore
 .yarnrc

--- a/generators/app/templates/ext-command-ts/gitignore
+++ b/generators/app/templates/ext-command-ts/gitignore
@@ -1,5 +1,7 @@
 out
 dist
 node_modules
+coverage/
+.nyc_output/
 .vscode-test/
 *.vsix

--- a/generators/app/templates/ext-command-ts/package.json
+++ b/generators/app/templates/ext-command-ts/package.json
@@ -48,6 +48,7 @@
 		<%- dep("@typescript-eslint/parser") %>,
 		<%- dep("glob") %>,
 		<%- dep("mocha") %>,
+		<%- dep("nyc") %>,
 		<%- dep("typescript") %>,
 		<%- dep("vscode-test") %><% if (insiders) { %>,
 		<%- dep("vscode-dts") %><% } if (webpack) { %>,

--- a/generators/app/templates/ext-command-ts/src/test/suite/nyc-coverage-test-runner.ts
+++ b/generators/app/templates/ext-command-ts/src/test/suite/nyc-coverage-test-runner.ts
@@ -1,0 +1,104 @@
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
+import { QuickPickItem, window } from 'vscode';
+
+// Based on
+// - https://github.com/microsoft/vscode-docs/issues/1096#issuecomment-543850032
+// - https://github.com/microsoft/vscode-js-debug/blob/master/src/test/testRunner.ts
+// - https://gitlab.com/gitlab-org/gitlab-vscode-extension/-/issues/224
+
+// !!!
+// !!! Coverage report will be empty with `*` as one of the `activationEvents` in `package.json`.
+// !!!
+
+function setupCoverage() {
+	const NYC = require('nyc');
+	const nyc = new NYC({
+		cwd: path.join(__dirname, '..', '..', '..'),
+		exclude: ['**/test/**', '.vscode-test/**'],
+		reporter: ['text', 'html'],
+		all: true,
+		instrument: true,
+		hookRequire: true,
+		hookRunInContext: true,
+		hookRunInThisContext: true,
+	});
+
+	nyc.reset();
+	nyc.wrap();
+
+	return nyc;
+}
+
+export async function run(): Promise<void> {
+	// Create the mocha test
+	const mocha = new Mocha({
+		ui: 'tdd',
+		color: true
+	});
+
+	const testsRoot = path.resolve(__dirname, '..');
+	const nyc = process.env.COVERAGE === '1' ? setupCoverage() : null;
+	const files = glob.sync('**/**.test.js', { cwd: testsRoot });
+
+	console.error(`       process.env.COVERAGE: [${process.env.COVERAGE}]`);
+	console.error(`   process.env.SELECT_SUITE: [${process.env.SELECT_SUITE}]`);
+	console.error(`process.env.CUR_OPENED_FILE: [${process.env.CUR_OPENED_FILE}]`);
+	console.error(`                  testsRoot: [${testsRoot}]`);
+
+	let suites: string[] = [];
+
+	if (process.env.SELECT_SUITE === '1') {
+		let curOpenedFile = process.env.CUR_OPENED_FILE;
+		if (curOpenedFile && !curOpenedFile.endsWith('.test')) {
+			curOpenedFile = curOpenedFile + '.test';
+		}
+
+		console.error('Suites:');
+
+		const items: QuickPickItem[] = files.map(file => {
+			console.error('  - ' + file);
+
+			const item: QuickPickItem = {
+				label: file,
+				picked: curOpenedFile ? file.includes(curOpenedFile) : false
+			};
+
+			return item;
+		});
+
+		const selected = await window.showQuickPick(items, {
+			canPickMany: true,
+			ignoreFocusOut: true,
+			placeHolder: 'Pick a one or more test suites to run'
+		});
+
+		suites = selected?.map(item => item.label) ?? [];
+
+	} else {
+		suites = files;
+	}
+
+	console.error('Selected:');
+
+	for (const file of suites) {
+		console.error('  - ' + file);
+		mocha.addFile(path.resolve(testsRoot, file));
+	}
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			mocha.run(failures =>
+				failures ? reject(new Error(`${failures} tests failed`)) : resolve(),
+			);
+		});
+	} catch (err) {
+		console.error(err);
+	} finally {
+		if (nyc) {
+			nyc.writeCoverageFile();
+			await nyc.report();
+		}
+	}
+}

--- a/generators/app/templates/ext-command-ts/vscode-webpack/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/launch.json
@@ -29,6 +29,25 @@
 				"${workspaceFolder}/out/test/**/*.js"
 			],
 			"preLaunchTask": "npm: test-watch"
+		},
+		{
+			"name": "Extension Tests (Select)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/nyc-coverage-test-runner"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm: test-watch",
+			"env": {
+				"COVERAGE": "0",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode-webpack/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/launch.json
@@ -48,6 +48,25 @@
 				"SELECT_SUITE": "1",
 				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
 			}
+		},
+		{
+			"name": "Extension Tests (Coverage)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/nyc-coverage-test-runner"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm: pretest",
+			"env": {
+				"COVERAGE": "1",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode-webpack/tasks.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/tasks.json
@@ -28,6 +28,20 @@
 				"reveal": "never"
 			},
 			"group": "build"
+		},
+		{
+			"type": "npm",
+			"script": "pretest",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: pretest",
+			"detail": "tsc -p ./",
+			"presentation": {
+				"reveal": "silent",
+				"panel": "shared",
+				"showReuseMessage": false,
+				"clear": true
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -29,6 +29,25 @@
 				"${workspaceFolder}/out/test/**/*.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Extension Tests (Select)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/nyc-coverage-test-runner"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"COVERAGE": "0",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -48,6 +48,25 @@
 				"SELECT_SUITE": "1",
 				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
 			}
+		},
+		{
+			"name": "Extension Tests (Coverage)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/nyc-coverage-test-runner"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm: pretest",
+			"env": {
+				"COVERAGE": "1",
+				"SELECT_SUITE": "1",
+				"CUR_OPENED_FILE": "${fileBasenameNoExtension}"
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode/tasks.json
+++ b/generators/app/templates/ext-command-ts/vscode/tasks.json
@@ -15,6 +15,20 @@
 				"kind": "build",
 				"isDefault": true
 			}
+		},
+		{
+			"type": "npm",
+			"script": "pretest",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: pretest",
+			"detail": "tsc -p ./",
+			"presentation": {
+				"reveal": "silent",
+				"panel": "shared",
+				"showReuseMessage": false,
+				"clear": true
+			}
 		}
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscodeignore
+++ b/generators/app/templates/ext-command-ts/vscodeignore
@@ -1,6 +1,8 @@
 .vscode/**
 .vscode-test/**
+.nyc_output/**
 <% if (webpack) { %>out/**<% } else { %>out/test/**<% } %>
+coverage/**
 src/**
 .gitignore
 .yarnrc

--- a/test/test.js
+++ b/test/test.js
@@ -700,6 +700,7 @@ describe('test code generator', function () {
                         "@typescript-eslint/eslint-plugin",
                         "glob",
                         "mocha",
+                        "nyc",
                         "typescript",
                         "vscode-test"
                     ]),
@@ -772,6 +773,7 @@ describe('test code generator', function () {
                         "@typescript-eslint/eslint-plugin",
                         "glob",
                         "mocha",
+                        "nyc",
                         "typescript",
                         "vscode-test"
                     ]),
@@ -865,6 +867,7 @@ describe('test code generator', function () {
                         "@typescript-eslint/eslint-plugin",
                         "glob",
                         "mocha",
+                        "nyc",
                         "typescript",
                         "vscode-test",
                         "webpack",
@@ -942,6 +945,7 @@ describe('test code generator', function () {
                         "eslint",
                         "glob",
                         "mocha",
+                        "nyc",
                         "typescript",
                         "vscode-test"
                     ]),


### PR DESCRIPTION
This PR adds GUI to pick a test suite files and ability to generate test coverage report.

![](https://github.com/keewek/vscode-nyc-coverage-example/raw/main/assets/docs/preselect.png)

Additions:

- `nyc` to `devDependencies`
- `npm: pretest` task which is used by 'Extension Tests (Coverage)' configuration
- `Extension Tests (Select)` configuration
    - Shows GUI to pick a test suite files
    - Preselects with currently open file

- `Extension Tests (Coverage)` configuration
    - Shows GUI to pick a test suite files
    - Preselects with currently open file
    - Generates a test coverage report

- Test runner
- GUI to pick a test suite files
- Preselect
    - Preselects currently open module's `.test.ts` suite file
        
        ![](https://github.com/keewek/vscode-nyc-coverage-example/raw/main/assets/docs/preselect.png)

    - Preselects currently open `.test.ts` suite file
        
        ![](https://github.com/keewek/vscode-nyc-coverage-example/raw/main/assets/docs/preselect-with-test.png)


These additions make it easier to see coverage report in isolation.

[Full example](https://github.com/keewek/vscode-nyc-coverage-example)