### PR TITLE
Fix autoClosingPairs and surroundingPairs to match IAutoClosingPair interface

### DIFF
--- a/generators/app/templates/ext-language/language-configuration.json
+++ b/generators/app/templates/ext-language/language-configuration.json
@@ -13,18 +13,18 @@
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"" },
+        { "open": "'", "close": "'" }
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"" },
+        { "open": "'", "close": "'" }
     ]
 }


### PR DESCRIPTION
The language-configuration.json file generated when created a language support extension didn't correctly match the [LanguageSupport interface ](https://github.com/microsoft/vscode/blob/29bc5baadc95a797cc0df8cc8e66cea3cd289e34/src/vs/editor/common/modes/languageConfiguration.ts#L26) (see #236).


#### Changes proposed in this Pull Request

- Fixed the values of the `autoClosingPars` and `surroundingPairs` properties, to match the [IAutoClosingPair interface](https://github.com/microsoft/vscode/blob/29bc5baadc95a797cc0df8cc8e66cea3cd289e34/src/vs/editor/common/modes/languageConfiguration.ts#L185).

#### Testing instructions

- Create a new grammar extension (run `yo code` and select the "New Language Support" option)
- Verify that the `autoClosingPars` and `surroundingPairs` properties in the `language-configuration.json` file match the [IAutoClosingPair interface](https://github.com/microsoft/vscode/blob/29bc5baadc95a797cc0df8cc8e66cea3cd289e34/src/vs/editor/common/modes/languageConfiguration.ts#L185).


Fixes #236 