### PR TITLE
Add section for extension guidelines

### DIFF
--- a/generators/app/templates/ext-command-ts/README.md
+++ b/generators/app/templates/ext-command-ts/README.md
@@ -48,6 +48,9 @@ Fixed issue #.
 Added features X, Y, and Z.
 
 -----------------------------------------------------------------------------------------------------------
+## Following extension guidelines
+Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
+* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
 
 ## Working with Markdown
 

--- a/generators/app/templates/ext-command-ts/README.md
+++ b/generators/app/templates/ext-command-ts/README.md
@@ -49,7 +49,9 @@ Added features X, Y, and Z.
 
 -----------------------------------------------------------------------------------------------------------
 ## Following extension guidelines
+
 Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
+
 * [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
 
 ## Working with Markdown


### PR DESCRIPTION
This adds a section for the extension guidelines in the readme docs (refs https://github.com/microsoft/vscode-docs/issues/4270)