### PR TITLE
fix: Update token inspection command

### DIFF
--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -10,7 +10,7 @@
 
 * Press `F5` to open a new window with your extension loaded.
 * Open `File > Preferences > Color Themes` and pick your color theme.
-* Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Inspect TM Scopes` command from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) .
+* Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Developer: Inspect Editor Tokens and Scopes` command from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) .
 
 ## Make changes
 


### PR DESCRIPTION
Inspect token command seems to have been renamed from `Inspect TM Themes` -> `Developer: Inspect Editor Tokens and Scopes`