### PR TITLE
Update vscode version api endpoint

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -5,7 +5,7 @@
 var request = require('request-light');
 
 var fallbackVersion = '^1.46.0';
-var promise = request.xhr({ url: 'https://vscode-update.azurewebsites.net/api/releases/stable', headers: { "X-API-Version": "2" } }).then(res => {
+var promise = request.xhr({ url: 'https://update.code.visualstudio.com/api/releases/stable', headers: { "X-API-Version": "2" } }).then(res => {
     if (res.status === 200) {
         try {
             var tagsAndCommits = JSON.parse(res.responseText);


### PR DESCRIPTION
The request for the most current vscode version fails with the following error:

```
Unable to fetch latest vscode version: Error:  {
  responseText: '<!DOCTYPE html>\n' +
    '<html lang="en">\n' +
    '<head>\n' +
    '<meta charset="utf-8">\n' +
    '<title>Error</title>\n' +
    '</head>\n' +
    '<body>\n' +
    '<pre>Cannot GET /api/releases/stable</pre>\n' +
    '</body>\n' +
    '</html>\n',
  status: 404,
  headers: {
    'content-length': '158',
    'content-type': 'text/html; charset=utf-8',
    'x-powered-by': 'Express',
    'content-security-policy': "default-src 'self'",
    'x-content-type-options': 'nosniff',
    date: 'Thu, 25 Mar 2021 20:43:19 GMT',
    connection: 'close'
  }
}
```

This is fixed by updating the api endpoint to `https://update.code.visualstudio.com/api/releases/stable`. This new endpoint can be found by looking at the root of the old endpoint (<https://vscode-update.azurewebsites.net/>) which reads as follows `Please use update.code.visualstudio.com instead.`.

This also addresses issue #251