### PR TITLE
Ignore `*.map` files when using webpack

### DIFF
--- a/generators/app/templates/ext-command-ts/vscodeignore
+++ b/generators/app/templates/ext-command-ts/vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 <% if (webpack) { %>out/**<% } else { %>out/test/**<% } %>
 <% if (webpack) { %>node_modules/**<% } %>
+<% if (webpack) { %>dist/**/*.map<% } %>
 src/**
 .gitignore
 .yarnrc


### PR DESCRIPTION
Just to make it bulletproof, as described in https://github.com/microsoft/vscode-generator-code/issues/261#issuecomment-831668377.

Fixes #261