### PR TITLE
:up: @types/node to 14.x

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -43,7 +43,7 @@ module.exports.getDependencyVersions = async function () {
         "@types/vscode": vscodeVersion,
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",
-        "@types/node": "^12.11.7",
+        "@types/node": "14.x",
         "@typescript-eslint/eslint-plugin": "^4.14.1",
         "@typescript-eslint/parser": "^4.14.1",
         "eslint": "^7.19.0",


### PR DESCRIPTION
This updates the node.js types to match our latest Electron version.

cc @deepak1556 