### PR TITLE
Web bits fix

### DIFF
--- a/generators/app/generate-web-update.js
+++ b/generators/app/generate-web-update.js
@@ -50,7 +50,7 @@ module.exports = {
                 "package-web": "webpack --mode production --devtool hidden-source-map --config ./build/web-extension.webpack.config.js",
             },
             'devDependencies': {
-                'v@vscode/test-web': dependencyVersions['@vscode/test-web'],
+                '@vscode/test-web': dependencyVersions['@vscode/test-web'],
                 'ts-loader': dependencyVersions['ts-loader'],
                 'webpack': dependencyVersions['webpack'],
                 'webpack-cli': dependencyVersions['webpack-cli'],

--- a/generators/app/generate-web-update.js
+++ b/generators/app/generate-web-update.js
@@ -60,6 +60,10 @@ module.exports = {
             }
         });
 
+        if(generator.fs.exists('.gitignore')) {
+            generator.fs.append('.gitignore', '.vscode-test-web/')
+        }
+
         generator.fs.copyTpl(generator.templatePath('src/web/extension.ts'), generator.destinationPath('src/web/extension.ts'), extensionConfig, {});
         generator.fs.copy(generator.templatePath('src/web/test'), generator.destinationPath('src/web/test'));
         generator.fs.copyTpl(generator.templatePath('build/web-extension.webpack.config.js'), generator.destinationPath('build/web-extension.webpack.config.js'), extensionConfig);


### PR DESCRIPTION
Related to #292

Fixes typo and adds vscode-web-test to gitignore.

Did not add web launch config because the generated `launch.json` and `tasks.json` files contain comments and the current file system library uses JSON.parse which doesn't allow for `//` comments.