### PR TITLE
Switch to new problem matcher extension

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode-webpack/vscode/extensions.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/vscode/extensions.json
@@ -3,6 +3,6 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"eamodio.tsl-problem-matcher"
+		"felipecrs.tsl-problem-matcher"
 	]
 }

--- a/generators/app/templates/ext-command-ts/vscode-webpack/webpack.config.js
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/webpack.config.js
@@ -40,6 +40,10 @@ const extensionConfig = {
       }
     ]
   },
-  devtool: 'nosources-source-map'
+  devtool: 'nosources-source-map',
+  // allow VS Code's build task to properly detect states in watch mode
+  infrastructureLogging: {
+    level: 'log',
+  },
 };
 module.exports = [ extensionConfig ];

--- a/generators/app/templates/ext-command-web/vscode/extensions.json
+++ b/generators/app/templates/ext-command-web/vscode/extensions.json
@@ -3,6 +3,6 @@
 	// for the documentation about the extensions.json format
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"eamodio.tsl-problem-matcher"
+		"felipecrs.tsl-problem-matcher"
 	]
 }

--- a/generators/app/templates/ext-command-web/webpack.config.js
+++ b/generators/app/templates/ext-command-web/webpack.config.js
@@ -59,7 +59,11 @@ const webExtensionConfig = {
 	performance: {
 		hints: false
 	},
-	devtool: 'nosources-source-map' // create a source map that points to the original source file
+	devtool: 'nosources-source-map', // create a source map that points to the original source file
+    // allow VS Code's build task to properly detect states in watch mode
+    infrastructureLogging: {
+        level: 'log',
+    },
 };
 
 module.exports = [ webExtensionConfig ];

--- a/generators/app/templates/ext-notebook-renderer/vscode/extensions.json
+++ b/generators/app/templates/ext-notebook-renderer/vscode/extensions.json
@@ -3,6 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "eamodio.tsl-problem-matcher"
+    "felipecrs.tsl-problem-matcher"
   ]
 }

--- a/generators/app/templates/ext-notebook-renderer/webpack.config.js
+++ b/generators/app/templates/ext-notebook-renderer/webpack.config.js
@@ -66,6 +66,10 @@ const makeConfig = (argv, { entry, out, target, library = 'commonjs' }) => ({
             scriptUrl: 'import.meta.url',
         }),
     ],
+    // allow VS Code's build task to properly detect states in watch mode
+    infrastructureLogging: {
+        level: 'log',
+    },
 });
 
 module.exports = (env, argv) => [


### PR DESCRIPTION
For these reasons:

1. @eamodio's extension changed its ID in the Marketplace, so the generator-code is currently broken anyway.
2. It lacks proper support for webpack-cli@4, not being able to detect whether a re-compilation has started on watch mode. See: https://github.com/eamodio/vscode-tsl-problem-matcher/pull/9#issuecomment-915436660
3. It is probably abandoned, as none of the recent PRs or Issues that were opened on it received any reaction.

Refs https://github.com/felipecrs/vscode-tsl-problem-matcher/pull/1
