### PR TITLE
change parameter order for the watch-test task

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode-webpack/package.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/package.json
@@ -28,7 +28,7 @@
 		"watch": "webpack --watch",
 		"package": "webpack --mode production --devtool hidden-source-map",
 		"compile-tests": "tsc -p . --outDir out",
-		"watch-tests": "tsc -p -w . --outDir out",
+		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "<%= pkgManager %> run compile-tests && <%= pkgManager %> run compile && <%= pkgManager %> run lint",
 		"lint": "eslint src --ext ts",
 		"test": "node ./out/test/runTest.js"<% if (insiders) { %>,

--- a/test/test.js
+++ b/test/test.js
@@ -781,7 +781,7 @@ describe('test code generator', function () {
                         "watch": "webpack --watch",
                         "package": "webpack --mode production --devtool hidden-source-map",
                         "compile-tests": "tsc -p . --outDir out",
-                        "watch-tests": "tsc -p -w . --outDir out",
+                        "watch-tests": "tsc -p . -w --outDir out",
                         "lint": "eslint src --ext ts",
                         "pretest": "npm run compile-tests && npm run compile && npm run lint",
                         "test": "node ./out/test/runTest.js"


### PR DESCRIPTION
Was creating a new extension and with a TS extension with webpack on I could not run the "Extension Tests" debug config. 

![image](https://user-images.githubusercontent.com/812783/139509986-f3e45ff1-8d6f-492e-95d1-04c9766182ea.png)

![image](https://user-images.githubusercontent.com/812783/139510018-005edef0-c8ff-44ce-b816-92b23421048d.png)

I believe the parameter order from here might be off as --project (-p) is looking for a string. https://github.com/microsoft/vscode-generator-code/commit/2fc804e857b543eda70efdaef920906c81893c14