### PR TITLE
use consistent bullet

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode-webpack/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/vsc-extension-quickstart.md
@@ -11,7 +11,7 @@
 
 ## Setup
 
-- install the recommended extensions (amodio.tsl-problem-matcher and dbaeumer.vscode-eslint)
+* install the recommended extensions (amodio.tsl-problem-matcher and dbaeumer.vscode-eslint)
 
 
 ## Get up and running straight away


### PR DESCRIPTION
Just noticed this little typo.  Every other bullet in this file uses `*`, but this one uses `-`.

![Screenshot_20211201_221926](https://user-images.githubusercontent.com/15232461/144351825-a296d796-4774-44e0-a475-16adc5de4f68.png)
