### PR TITLE
Have git init use an initial branch of main

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -185,7 +185,7 @@ module.exports = class extends Generator {
 
         // Git init
         if (this.extensionConfig.gitInit) {
-            this.spawnCommand('git', ['init', '--quiet']);
+            this.spawnCommand('git', ['init', '--quiet', '--initial-branch=main']);
         }
 
         if (this.extensionConfig.proposedAPI) {

--- a/generators/app/templates/ext-localization/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-localization/vsc-extension-quickstart.md
@@ -20,7 +20,7 @@ To create/update the `translations` folder with the latest strings from transife
 
 * Get an API token from https://www.transifex.com/user/settings/api. The token needs to have access to the `vscode-editor`, `vscode-workbench` and `vscode-extensions` projects.
 * Set the API token to the environment variable `TRANSIFEX_API_TOKEN`.
-* Check out the `master` branch of the [VS Code repository](https://github.com/Microsoft/vscode).
+* Check out the `main` branch of the [VS Code repository](https://github.com/Microsoft/vscode).
   * Preferably, place the VSCode repo next to the language pack extension (so both have the same parent folder).
   * `cd vscode` and run `yarn` to initialize the VS Code repo. More information on how to build VS Code you can find [here](https://github.com/Microsoft/vscode/wiki/How-to-Contribute).
   * If the language pack extension is placed next to the VS Code repository: `npm run update-localization-extension <%- lpLanguageId %>`


### PR DESCRIPTION
I recently generated a new extension and it was surprising to me that the default branch is `master` when GitHub as a whole has transitioned to `main`. 

The downside to this change is that I believe the `init.defaultBranch` global git configuration won't be respected due to the command line argument although I haven't tested that. I still believe this is a good change as the user can go and change the branch rather easily once the repo is generated, but this is a better default behavior. The docs for `--initial-branch` can be found here https://git-scm.com/docs/git-init