### PR TITLE
Fix for ext-snippets quick start documentation

### DIFF
--- a/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-snippets/vsc-extension-quickstart.md
@@ -4,7 +4,7 @@
 
 * This folder contains all of the files necessary for your extension.
 * `package.json` - this is the manifest file that defines the location of the snippet file and specifies the language of the snippets.
-* `snippets/snippets.json` - the file containing all snippets.
+* `snippets/snippets.code-snippets` - the file containing all snippets.
 
 ## Get up and running straight away
 


### PR DESCRIPTION
Corrected snippets filename in vsc-extension quick start documentation.