### PR TITLE
fix: target ES2020 in web extensions

### DIFF
--- a/generators/app/templates/ext-command-web/tsconfig.json
+++ b/generators/app/templates/ext-command-web/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "ES2020",
 		"outDir": "dist",
 		"lib": [
-			"es6", "WebWorker"
+			"ES2020", "WebWorker"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
ES6 is very old and downlevels async/await into iterators, which runs slowly and makes debugging painful. Targeting ES2020 [works for Node 14](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) and modern browsers are already happy with ES2021 or newer.