### PR TITLE
Remove $tslint-webpack-watch from vscode-webpack template

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode-webpack/vscode/tasks.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/vscode/tasks.json
@@ -6,10 +6,7 @@
 		{
 			"type": "npm",
 			"script": "watch",
-			"problemMatcher": [
-				"$ts-webpack-watch",
-				"$tslint-webpack-watch"
-			],
+			"problemMatcher": "$ts-webpack-watch",
 			"isBackground": true,
 			"presentation": {
 				"reveal": "never",


### PR DESCRIPTION
AFAIK TSLint is dead, and the replacement ESLint isn't being ran from the generated webpack configuration anyhow.