### PR TITLE
Fix incorrect keyboard shortcut listed in template READMEs

### DIFF
--- a/generators/app/templates/ext-colortheme/README.md
+++ b/generators/app/templates/ext-colortheme/README.md
@@ -4,7 +4,7 @@ You can author your README using Visual Studio Code.  Here are some useful edito
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 * [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)

--- a/generators/app/templates/ext-command-js/README.md
+++ b/generators/app/templates/ext-command-js/README.md
@@ -55,7 +55,7 @@ Added features X, Y, and Z.
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 

--- a/generators/app/templates/ext-command-ts/README.md
+++ b/generators/app/templates/ext-command-ts/README.md
@@ -60,7 +60,7 @@ Ensure that you've read through the extensions guidelines and follow the best pr
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 

--- a/generators/app/templates/ext-command-web/README.md
+++ b/generators/app/templates/ext-command-web/README.md
@@ -55,7 +55,7 @@ Added features X, Y, and Z.
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 

--- a/generators/app/templates/ext-extensionpack/README.md
+++ b/generators/app/templates/ext-extensionpack/README.md
@@ -6,7 +6,7 @@ You can author your README using Visual Studio Code.  Here are some useful edito
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ## For more information
 

--- a/generators/app/templates/ext-keymap/README.md
+++ b/generators/app/templates/ext-keymap/README.md
@@ -4,7 +4,7 @@ You can author your README using Visual Studio Code.  Here are some useful edito
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 * [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)

--- a/generators/app/templates/ext-language/README.md
+++ b/generators/app/templates/ext-language/README.md
@@ -55,7 +55,7 @@ Added features X, Y, and Z.
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 

--- a/generators/app/templates/ext-snippets/README.md
+++ b/generators/app/templates/ext-snippets/README.md
@@ -55,7 +55,7 @@ Added features X, Y, and Z.
 
 * Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
 * Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets
 
 ### For more information
 


### PR DESCRIPTION
### Description of changes

Resolves #353 

Changes all instances of:

> Press Ctrl+Space (Windows, Linux) or Cmd+Space (macOS) to see a list of Markdown snippets

to 

> Press Ctrl+Space (Windows, Linux, macOS) to see a list of Markdown snippets