### PR TITLE
chore: Unify indentation in generated package.json

### DIFF
--- a/generators/app/templates/ext-colortheme/package.json
+++ b/generators/app/templates/ext-colortheme/package.json
@@ -1,21 +1,21 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Themes"
-    ],
-    "contributes": {
-        "themes": [
-            {
-                "label": <%- JSON.stringify(themeName) %>,
-                "uiTheme": <%- JSON.stringify(themeBase) %>,
-                "path": <%- JSON.stringify("./themes/" + themeFileName) %>
-            }
-        ]
-    }
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Themes"
+  ],
+  "contributes": {
+    "themes": [
+      {
+        "label": <%- JSON.stringify(themeName) %>,
+        "uiTheme": <%- JSON.stringify(themeBase) %>,
+        "path": <%- JSON.stringify("./themes/" + themeFileName) %>
+      }
+    ]
+  }
 }

--- a/generators/app/templates/ext-command-js/package.json
+++ b/generators/app/templates/ext-command-js/package.json
@@ -1,40 +1,38 @@
 {
   "name": <%- JSON.stringify(name) %>,
-	"displayName": <%- JSON.stringify(displayName) %>,
-	"description": <%- JSON.stringify(description) %>,
-	"version": "0.0.1",
-	"engines": {
-		"vscode": <%- JSON.stringify(vsCodeEngine) %>
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-        <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
-	],
-	"main": "./extension.js",
-	"contributes": {
-		"commands": [{
-            "command": <%- JSON.stringify(`${name}.helloWorld`) %>,
-            "title": "Hello World"
-
-		}]
-	},
-	"scripts": {
-		"lint": "eslint .",
-		"pretest": "<%= pkgManager %> run lint",
-		"test": "node ./test/runTest.js"
-	},
-	"devDependencies": {
-        <%- dep("@types/vscode") %>,
-        <%- dep("@types/glob") %>,
-        <%- dep("@types/mocha") %>,
-        <%- dep("@types/node") %>,
-        <%- dep("eslint") %>,
-        <%- dep("glob") %>,
-        <%- dep("mocha") %>,
-        <%- dep("typescript") %>,
-        <%- dep("@vscode/test-electron") %>
-    }
-
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "commands": [{
+      "command": <%- JSON.stringify(`${name}.helloWorld`) %>,
+      "title": "Hello World"
+    }]
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "pretest": "<%= pkgManager %> run lint",
+    "test": "node ./test/runTest.js"
+  },
+  "devDependencies": {
+    <%- dep("@types/vscode") %>,
+    <%- dep("@types/glob") %>,
+    <%- dep("@types/mocha") %>,
+    <%- dep("@types/node") %>,
+    <%- dep("eslint") %>,
+    <%- dep("glob") %>,
+    <%- dep("mocha") %>,
+    <%- dep("typescript") %>,
+    <%- dep("@vscode/test-electron") %>
+  }
 }

--- a/generators/app/templates/ext-command-ts/package.json
+++ b/generators/app/templates/ext-command-ts/package.json
@@ -1,48 +1,48 @@
 {
   "name": <%- JSON.stringify(name) %>,
-	"displayName": <%- JSON.stringify(displayName) %>,
-	"description": <%- JSON.stringify(description) %>,
-	"version": "0.0.1",
-	"engines": {
-		"vscode": <%- JSON.stringify(vsCodeEngine) %>
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-        <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
-	],
-	"main": "./out/extension.js",<% if (insiders) { %>
-	"enabledApiProposals": [],<% } %>
-	"contributes": {
-		"commands": [
-			{
-				"command": <%- JSON.stringify(`${name}.helloWorld`) %>,
-				"title": "Hello World"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "<%= pkgManager %> run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "<%= pkgManager %> run compile && <%= pkgManager %> run lint",
-		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"<% if (insiders) { %>,
-		"update-proposed-api": "vscode-dts dev"<% } %>
-	},
-	"devDependencies": {
-		<%- dep("@types/vscode") %>,
-		<%- dep("@types/glob") %>,
-		<%- dep("@types/mocha") %>,
-		<%- dep("@types/node") %>,
-		<%- dep("@typescript-eslint/eslint-plugin") %>,
-		<%- dep("@typescript-eslint/parser") %>,
-		<%- dep("eslint") %>,
-		<%- dep("glob") %>,
-		<%- dep("mocha") %>,
-		<%- dep("typescript") %>,
-		<%- dep("@vscode/test-electron") %><% if (insiders) { %>,
-		<%- dep("vscode-dts") %><% } %>
-	}
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
+  ],
+  "main": "./out/extension.js",<% if (insiders) { %>
+  "enabledApiProposals": [],<% } %>
+  "contributes": {
+    "commands": [
+      {
+        "command": <%- JSON.stringify(`${name}.helloWorld`) %>,
+        "title": "Hello World"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "<%= pkgManager %> run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "<%= pkgManager %> run compile && <%= pkgManager %> run lint",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"<% if (insiders) { %>,
+    "update-proposed-api": "vscode-dts dev"<% } %>
+  },
+  "devDependencies": {
+    <%- dep("@types/vscode") %>,
+    <%- dep("@types/glob") %>,
+    <%- dep("@types/mocha") %>,
+    <%- dep("@types/node") %>,
+    <%- dep("@typescript-eslint/eslint-plugin") %>,
+    <%- dep("@typescript-eslint/parser") %>,
+    <%- dep("eslint") %>,
+    <%- dep("glob") %>,
+    <%- dep("mocha") %>,
+    <%- dep("typescript") %>,
+    <%- dep("@vscode/test-electron") %><% if (insiders) { %>,
+    <%- dep("vscode-dts") %><% } %>
+  }
 }

--- a/generators/app/templates/ext-command-ts/vscode-webpack/package.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/package.json
@@ -1,54 +1,54 @@
 {
   "name": <%- JSON.stringify(name) %>,
-	"displayName": <%- JSON.stringify(displayName) %>,
-	"description": <%- JSON.stringify(description) %>,
-	"version": "0.0.1",
-	"engines": {
-		"vscode": <%- JSON.stringify(vsCodeEngine) %>
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-        <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
-	],
-	"main": "./dist/extension.js",<% if (insiders) { %>
-	"enabledApiProposals": [],<% } %>
-	"contributes": {
-		"commands": [
-			{
-				"command": <%- JSON.stringify(`${name}.helloWorld`) %>,
-				"title": "Hello World"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "<%= pkgManager %> run package",
-		"compile": "webpack",
-		"watch": "webpack --watch",
-		"package": "webpack --mode production --devtool hidden-source-map",
-		"compile-tests": "tsc -p . --outDir out",
-		"watch-tests": "tsc -p . -w --outDir out",
-		"pretest": "<%= pkgManager %> run compile-tests && <%= pkgManager %> run compile && <%= pkgManager %> run lint",
-		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"<% if (insiders) { %>,
-		"update-proposed-api": "vscode-dts dev"<% } %>
-	},
-	"devDependencies": {
-		<%- dep("@types/vscode") %>,
-		<%- dep("@types/glob") %>,
-		<%- dep("@types/mocha") %>,
-		<%- dep("@types/node") %>,
-		<%- dep("@typescript-eslint/eslint-plugin") %>,
-		<%- dep("@typescript-eslint/parser") %>,
-		<%- dep("eslint") %>,
-		<%- dep("glob") %>,
-		<%- dep("mocha") %>,
-		<%- dep("typescript") %>,
-		<%- dep("ts-loader") %>,
-		<%- dep("webpack") %>,
-		<%- dep("webpack-cli") %>,
-		<%- dep("@vscode/test-electron") %><% if (insiders) { %>,
-		<%- dep("vscode-dts") %><% } %>
-	}
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
+  ],
+  "main": "./dist/extension.js",<% if (insiders) { %>
+  "enabledApiProposals": [],<% } %>
+  "contributes": {
+    "commands": [
+      {
+        "command": <%- JSON.stringify(`${name}.helloWorld`) %>,
+        "title": "Hello World"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "<%= pkgManager %> run package",
+    "compile": "webpack",
+    "watch": "webpack --watch",
+    "package": "webpack --mode production --devtool hidden-source-map",
+    "compile-tests": "tsc -p . --outDir out",
+    "watch-tests": "tsc -p . -w --outDir out",
+    "pretest": "<%= pkgManager %> run compile-tests && <%= pkgManager %> run compile && <%= pkgManager %> run lint",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"<% if (insiders) { %>,
+    "update-proposed-api": "vscode-dts dev"<% } %>
+  },
+  "devDependencies": {
+    <%- dep("@types/vscode") %>,
+    <%- dep("@types/glob") %>,
+    <%- dep("@types/mocha") %>,
+    <%- dep("@types/node") %>,
+    <%- dep("@typescript-eslint/eslint-plugin") %>,
+    <%- dep("@typescript-eslint/parser") %>,
+    <%- dep("eslint") %>,
+    <%- dep("glob") %>,
+    <%- dep("mocha") %>,
+    <%- dep("typescript") %>,
+    <%- dep("ts-loader") %>,
+    <%- dep("webpack") %>,
+    <%- dep("webpack-cli") %>,
+    <%- dep("@vscode/test-electron") %><% if (insiders) { %>,
+    <%- dep("vscode-dts") %><% } %>
+  }
 }

--- a/generators/app/templates/ext-command-web/package.json
+++ b/generators/app/templates/ext-command-web/package.json
@@ -1,52 +1,50 @@
 {
-	"name": <%- JSON.stringify(name) %>,
-	"displayName": <%- JSON.stringify(displayName) %>,
-	"description": <%- JSON.stringify(description) %>,
-	"version": "0.0.1",
-	"engines": {
-		"vscode": <%- JSON.stringify(vsCodeEngine) %>
-	},
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-        <%- JSON.stringify(`onCommand:${name
-		}.helloWorld`) %>
-	],
-	"browser": "./dist/web/extension.js",
-	"contributes": {
-		"commands": [
-			{
-				"command": <%- JSON.stringify(`${name
-				}.helloWorld`) %>,
-				"title": "Hello World"
-			}
-		]
-	},
-	"scripts": {
-		"test": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/index.js",
-		"pretest": "<%= pkgManager %> run compile-web",
-		"vscode:prepublish": "<%= pkgManager %> run package-web",
-		"compile-web": "webpack",
-		"watch-web": "webpack --watch",
-		"package-web": "webpack --mode production --devtool hidden-source-map",
-		"lint": "eslint src --ext ts",
-		"run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
-	},
-	"devDependencies": {
-		<%- dep("@types/vscode") %>,
-		<%- dep("@types/mocha") %>,
-		<%- dep("eslint") %>,
-		<%- dep("@typescript-eslint/eslint-plugin") %>,
-		<%- dep("@typescript-eslint/parser") %>,
-		<%- dep("mocha") %>,
-		<%- dep("typescript") %>,
-		<%- dep("@vscode/test-web") %>,
-		<%- dep("ts-loader") %>,
-		<%- dep("webpack") %>,
-		<%- dep("webpack-cli") %>,
-		<%- dep("@types/webpack-env") %>,
-		<%- dep("assert") %>,
-		<%- dep("process") %>
-	}
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    <%- JSON.stringify(`onCommand:${name}.helloWorld`) %>
+  ],
+  "browser": "./dist/web/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": <%- JSON.stringify(`${name}.helloWorld`) %>,
+        "title": "Hello World"
+      }
+    ]
+  },
+  "scripts": {
+    "test": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/index.js",
+    "pretest": "<%= pkgManager %> run compile-web",
+    "vscode:prepublish": "<%= pkgManager %> run package-web",
+    "compile-web": "webpack",
+    "watch-web": "webpack --watch",
+    "package-web": "webpack --mode production --devtool hidden-source-map",
+    "lint": "eslint src --ext ts",
+    "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
+  },
+  "devDependencies": {
+    <%- dep("@types/vscode") %>,
+    <%- dep("@types/mocha") %>,
+    <%- dep("eslint") %>,
+    <%- dep("@typescript-eslint/eslint-plugin") %>,
+    <%- dep("@typescript-eslint/parser") %>,
+    <%- dep("mocha") %>,
+    <%- dep("typescript") %>,
+    <%- dep("@vscode/test-web") %>,
+    <%- dep("ts-loader") %>,
+    <%- dep("webpack") %>,
+    <%- dep("webpack-cli") %>,
+    <%- dep("@types/webpack-env") %>,
+    <%- dep("assert") %>,
+    <%- dep("process") %>
+  }
 }

--- a/generators/app/templates/ext-extensionpack/package.json
+++ b/generators/app/templates/ext-extensionpack/package.json
@@ -1,16 +1,16 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Extension Packs"
-    ],
-    "extensionPack": [ <% for (i=0; i<extensionList.length-1; i++) { %>
-        "<%- extensionList[i] %>", <%}%>
-        "<%- extensionList[extensionList.length-1]%>"
-    ]
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Extension Packs"
+  ],
+  "extensionPack": [ <% for (i=0; i<extensionList.length-1; i++) { %>
+    "<%- extensionList[i] %>", <%}%>
+    "<%- extensionList[extensionList.length-1]%>"
+  ]
 }

--- a/generators/app/templates/ext-keymap/package.json
+++ b/generators/app/templates/ext-keymap/package.json
@@ -1,20 +1,20 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Keymaps"
-    ],
-    "contributes": {
-        "keybindings": [
-            {
-                "key": "ctrl+.",
-                "command": "workbench.action.showCommands"
-            }
-        ]
-    }
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Keymaps"
+  ],
+  "contributes": {
+    "keybindings": [
+      {
+        "key": "ctrl+.",
+        "command": "workbench.action.showCommands"
+      }
+    ]
+  }
 }

--- a/generators/app/templates/ext-language/package.json
+++ b/generators/app/templates/ext-language/package.json
@@ -1,25 +1,25 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Programming Languages"
-    ],
-    "contributes": {
-        "languages": [{
-            "id": <%- JSON.stringify(languageId) %>,
-            "aliases": [<%- JSON.stringify(languageName) %>, <%- JSON.stringify(languageId) %>],
-            "extensions": <%- JSON.stringify(languageExtensions) %>,
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": <%- JSON.stringify(languageId) %>,
-            "scopeName": <%- JSON.stringify(languageScopeName) %>,
-            "path": <%- JSON.stringify("./syntaxes/" + languageFileName) %>
-        }]
-    }
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": <%- JSON.stringify(languageId) %>,
+      "aliases": [<%- JSON.stringify(languageName) %>, <%- JSON.stringify(languageId) %>],
+      "extensions": <%- JSON.stringify(languageExtensions) %>,
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": <%- JSON.stringify(languageId) %>,
+      "scopeName": <%- JSON.stringify(languageScopeName) %>,
+      "path": <%- JSON.stringify("./syntaxes/" + languageFileName) %>
+    }]
+  }
 }

--- a/generators/app/templates/ext-localization/package.json
+++ b/generators/app/templates/ext-localization/package.json
@@ -1,22 +1,22 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Language Packs"
-    ],
-    "contributes": {
-        "localizations": [{
-            "languageId": <%- JSON.stringify(lpLanguageId) %>,
-            "languageName": <%- JSON.stringify(lpLanguageName) %>,
-            "localizedLanguageName": <%- JSON.stringify(lpLocalizedLanguageName) %>
-        }]
-    },
-    "scripts": {
-        "update": "cd ../vscode && <%= pkgManager %> run update-localization-extension <%- lpLanguageId %>"
-    }
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Language Packs"
+  ],
+  "contributes": {
+    "localizations": [{
+      "languageId": <%- JSON.stringify(lpLanguageId) %>,
+      "languageName": <%- JSON.stringify(lpLanguageName) %>,
+      "localizedLanguageName": <%- JSON.stringify(lpLocalizedLanguageName) %>
+    }]
+  },
+  "scripts": {
+    "update": "cd ../vscode && <%= pkgManager %> run update-localization-extension <%- lpLanguageId %>"
+  }
 }

--- a/generators/app/templates/ext-snippets/package.json
+++ b/generators/app/templates/ext-snippets/package.json
@@ -1,20 +1,20 @@
 {
-    "name": <%- JSON.stringify(name) %>,
-    "displayName": <%- JSON.stringify(displayName) %>,
-    "description": <%- JSON.stringify(description) %>,
-    "version": "0.0.1",
-    "engines": {
-        "vscode": <%- JSON.stringify(vsCodeEngine) %>
-    },
-    "categories": [
-        "Snippets"
-    ],
-    "contributes": {
-        "snippets": [
-            {
-                "language": <%- JSON.stringify(languageId) %>,
-                "path": "./snippets/snippets.code-snippets"
-            }
-        ]
-    }
+  "name": <%- JSON.stringify(name) %>,
+  "displayName": <%- JSON.stringify(displayName) %>,
+  "description": <%- JSON.stringify(description) %>,
+  "version": "0.0.1",
+  "engines": {
+    "vscode": <%- JSON.stringify(vsCodeEngine) %>
+  },
+  "categories": [
+    "Snippets"
+  ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": <%- JSON.stringify(languageId) %>,
+        "path": "./snippets/snippets.code-snippets"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Hi :wave:

First of all thanks for this template, it was really useful for me in the past :+1: .

Last time I generated skeleton for vscode TS extension I noticed that `package.json` is always reformatted by [prettier](https://prettier.io/). There are inconsistencies between different package.json (across plugins, some use 2 spaces, some 4 spaces, some tabs, and some are mixed) and even directly in [TS package.json](https://github.com/microsoft/vscode-generator-code/blob/main/generators/app/templates/ext-command-ts/package.json#L2) indentation. Field `name` uses different indentation than `displayName`. See attached image.

![image](https://user-images.githubusercontent.com/26434056/176936494-b24b60e4-ed10-428f-80d6-3fb1cc1ada11.png)

Maybe some people will be against following prettier defaults (using spaces with tab width 2). But I think it's fairly popular tool and it's better to have the indentation consistent rather than random indentation.

Another way might be to add `yes/No` option at the end of generator dialog that will try to format the all relevant files after generation step is done.

This PR is just to kick of discussion if the maintainers would be open to such change. If so, I will try to properly test if I did not break any of the jsons.