### PR TITLE
Add link to UX guidelines in quickstart markdown files

### DIFF
--- a/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-js/vsc-extension-quickstart.md
@@ -35,5 +35,6 @@
   * You can create folders inside the `test` folder to structure your tests any way you want.
 ## Go further
 
+ * [Follow UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to create extensions that seamlessly integrate with VS Code's native interface and patterns.
  * [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VSCode extension marketplace.
  * Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).

--- a/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-ts/vsc-extension-quickstart.md
@@ -37,6 +37,7 @@
 
 ## Go further
 
+* [Follow UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to create extensions that seamlessly integrate with VS Code's native interface and patterns.
  * Reduce the extension size and improve the startup time by [bundling your extension](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).
  * [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VSCode extension marketplace.
  * Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).

--- a/generators/app/templates/ext-command-web/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-web/vsc-extension-quickstart.md
@@ -38,6 +38,7 @@
 
 ## Go further
 
+* [Follow UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) to create extensions that seamlessly integrate with VS Code's native interface and patterns.
 * Check out the [Web Extension Guide](https://code.visualstudio.com/api/extension-guides/web-extensions)
 * [Publish your extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) on the VSCode extension marketplace.
 * Automate builds by setting up [Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration).


### PR DESCRIPTION
Resolves #352

Adds a link to the extension [UX guidelines](https://code.visualstudio.com/api/ux-guidelines/overview) in any extension template that has a "Go further" section in its `vsc-extension-quickstart.md` file (aka the `ext-command-js`, `ext-command-ts`, and `ext-command-web` templates).