### PR TITLE
Limit webpack chunks for web extensions

### DIFF
--- a/generators/app/templates/ext-command-web/webpack.config.js
+++ b/generators/app/templates/ext-command-web/webpack.config.js
@@ -49,6 +49,9 @@ const webExtensionConfig = {
 		}]
 	},
 	plugins: [
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1 // disable chunks by default since web extensions must be a single bundle
+		}),
 		new webpack.ProvidePlugin({
 			process: 'process/browser', // provide a shim for the global `process` variable
 		}),


### PR DESCRIPTION
Refs
- https://github.com/microsoft/vscode/issues/155225 
- https://github.com/microsoft/vscode/pull/155226#issuecomment-1185199509

Web extensions cannot lazy load additional modules. We recently had to update several web extensions which were using webpack to not lazy load chunks. If we include this by default in the generator this should reduce issues for web extension authors in future. fyi @lramos15