### PR TITLE
Dom fix

### DIFF
--- a/generators/app/templates/ext-command-ts/tsconfig.json
+++ b/generators/app/templates/ext-command-ts/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "ES2020",
 		"outDir": "out",
 		"lib": [
-			"ES2020"
+			"ES2020",
+			"dom"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/generators/app/templates/ext-command-ts/vscode-webpack/tsconfig.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/tsconfig.json
@@ -3,7 +3,8 @@
 		"module": "commonjs",
 		"target": "ES2020",
 		"lib": [
-			"ES2020"
+			"ES2020",
+			"dom"
 		],
 		"sourceMap": true,
 		"rootDir": "src",

--- a/generators/app/templates/ext-command-ts/vscode-webpack/tsconfig.json
+++ b/generators/app/templates/ext-command-ts/vscode-webpack/tsconfig.json
@@ -3,8 +3,7 @@
 		"module": "commonjs",
 		"target": "ES2020",
 		"lib": [
-			"ES2020",
-			"dom"
+			"ES2020"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
I was running 
- 2017 Macbook Pro 
- Monterey 12.5.1
- VSCode 1.72.2
- NPM 8.19.2
When attempting to launch the "Run Extension" configuration I would get the following error 
`'Blob' could not be find`
adding `dom` to the `tsconfig` compiler libraries fixes the problem 