### PR TITLE
Replace deprecated GitHub action for headless tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - name: Run headless test
-      uses: GabrielBB/xvfb-action@v1
+      uses: coactions/setup-xvfb@v1
       with:
         run: npm test


### PR DESCRIPTION
This replaces the GitHub action used to run headless tests with the recommend one.

Note: The [original action is deprecated](https://github.com/GabrielBB/xvfb-action#%EF%B8%8F-deprecated-xvfb-github-action) and recommends the [new action](https://github.com/coactions/setup-xvfb) that's used in these changes