### PR TITLE
Don't force initial Git branch name. Instead use the users default initial branch name.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -185,7 +185,7 @@ module.exports = class extends Generator {
 
         // Git init
         if (this.extensionConfig.gitInit) {
-            this.spawnCommand('git', ['init', '--quiet', '--initial-branch=main']);
+            this.spawnCommand('git', ['init', '--quiet']);
         }
 
         if (this.extensionConfig.proposedAPI) {


### PR DESCRIPTION
Hi,

Currently, if you opt to use Git, the extension will force the initial branch name to `main`, overriding any user's default initial branch name.  

I think this is a little over-opinionated. The default initial branch name when you install Git is already `main` unless you specify to change it during the installation, so a simple `git init` would suffice there and would also work for people to choose to use a different default branch name like `master` and thus have that set in their global git config. 

Thanks,
D