### PR TITLE
Fix outFiles in launch.json

### DIFF
--- a/generators/app/templates/ext-command-ts/vscode/launch.json
+++ b/generators/app/templates/ext-command-ts/vscode/launch.json
@@ -26,7 +26,7 @@
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
+				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
 		}


### PR DESCRIPTION
If you limit it to the `test` folder, the debugger will show `.js` source files and only test `.ts` files.