### PR TITLE
generated quickstart guide says use npm even though project chose yarn

### DIFF
--- a/generators/app/templates/ext-command-web/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-command-web/vsc-extension-quickstart.md
@@ -13,7 +13,7 @@
 
 ## Get up and running the Web Extension
 
-* Run `npm install`.
+* Run `<%= pkgManager %> install`.
 * Place breakpoints in `src/web/extension.ts`.
 * Debug via F5 (Run Web Extension).
 * Execute extension code via `F1 > Hello world`.


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-generator-code/issues/478