### PR TITLE
Update vsc-extension-quickstart.md

### DIFF
--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -9,7 +9,7 @@
 ## Get up and running straight away
 
 * Press `F5` to open a new window with your extension loaded.
-* Open `File > Preferences > Theme > Color Theme` and pick your color theme.
+* Open the color theme picker with  the `File > Preferences > Theme > Color Theme` menu item, or use the `Preferences: Color Theme command (Ctrl+K Ctrl+T)` and pick your theme
 * Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Developer: Inspect Editor Tokens and Scopes` command from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac).
 
 ## Make changes

--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -9,7 +9,7 @@
 ## Get up and running straight away
 
 * Press `F5` to open a new window with your extension loaded.
-* Open `File > Preferences > Color Themes` and pick your color theme.
+* Open `File > Preferences > Color Themes` and pick your color theme. (`Code > Settings > Theme > Color Theme` on Mac)
 * Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Developer: Inspect Editor Tokens and Scopes` command from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac).
 
 ## Make changes

--- a/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
+++ b/generators/app/templates/ext-colortheme/vsc-extension-quickstart.md
@@ -9,7 +9,7 @@
 ## Get up and running straight away
 
 * Press `F5` to open a new window with your extension loaded.
-* Open `File > Preferences > Color Themes` and pick your color theme. (`Code > Settings > Theme > Color Theme` on Mac)
+* Open `File > Preferences > Theme > Color Theme` and pick your color theme.
 * Open a file that has a language associated. The languages' configured grammar will tokenize the text and assign 'scopes' to the tokens. To examine these scopes, invoke the `Developer: Inspect Editor Tokens and Scopes` command from the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac).
 
 ## Make changes


### PR DESCRIPTION
📝 Add Mac's menu hierarchy to get to the Theme switcher

<img width="783" alt="image" src="https://github.com/user-attachments/assets/bee3561e-ca93-4891-a9b9-9e17e1534c8d">
