### PR TITLE
Fix .vscodeignore for web extension to ignore built test files properly

### DIFF
--- a/generators/app/templates/ext-command-web/.vscodeignore
+++ b/generators/app/templates/ext-command-web/.vscodeignore
@@ -3,7 +3,7 @@
 src/**
 out/**
 node_modules/**
-dist/test/**
+dist/**/test/**
 .gitignore
 vsc-extension-quickstart.md
 webpack.config.js


### PR DESCRIPTION
The built `dist` directory looks like this:
```
dist
└── web
    ├── extension.js
    └── test
        └── suite
            └── extensionTests.js
```

So `dist/test/**` should be changed to `dist/**/test/**` to ignore the built test files.