### PR TITLE
Avoid referencing not-yet published `@types/vscode` versions

### DIFF
--- a/generators/app/env.js
+++ b/generators/app/env.js
@@ -7,34 +7,38 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-const fallbackVersion = '^1.54.0';
+const fallbackVersion = '^1.103.0';
 let versionPromise = undefined;
 
 export function getLatestVSCodeVersion() {
     if (!versionPromise) {
-        versionPromise = request.xhr({ url: 'https://update.code.visualstudio.com/api/releases/stable', headers: { "X-API-Version": "2" } }).then(res => {
-            if (res.status === 200) {
-                try {
-                    var tagsAndCommits = JSON.parse(res.responseText);
-                    if (Array.isArray(tagsAndCommits) && tagsAndCommits.length > 0) {
-                        var segments = tagsAndCommits[0].version.split('.');
-                        if (segments.length === 3) {
-                            return '^' + segments[0] + '.' + segments[1] + '.0';
+        // Fetch the latest published @types/vscode version from the npm registry
+        // and return a caret-pinned range (e.g. ^1.93.0).
+        versionPromise = request
+            .xhr({ url: 'https://registry.npmjs.org/@types/vscode/latest', headers: { 'Accept': 'application/json' } })
+            .then(
+                res => {
+                    if (res.status === 200) {
+                        try {
+                            const meta = JSON.parse(res.responseText);
+                            if (meta && typeof meta.version === 'string' && meta.version) {
+                                return '^' + meta.version;
+                            }
+                        } catch (e) {
+                            console.log('Problem parsing @types/vscode metadata: ' + res.responseText, e);
                         }
+                    } else {
+                        console.warn('Unable to evaluate the latest @types/vscode version: Status code: ' + res.status + ', ' + res.responseText);
                     }
-                } catch (e) {
-                    console.log('Problem parsing version: ' + res.responseText, e);
+                    console.warn('Falling back to: ' + fallbackVersion);
+                    return fallbackVersion;
+                },
+                err => {
+                    console.warn('Unable to evaluate the latest @types/vscode version: Error: ', err);
+                    console.warn('Falling back to: ' + fallbackVersion);
+                    return fallbackVersion;
                 }
-            } else {
-                console.warn('Unable to evaluate the latest vscode version: Status code: ' + res.status + ', ' + res.responseText);
-            }
-            console.warn('Falling back to: ' + fallbackVersion);
-            return fallbackVersion;
-        }, err => {
-            console.warn('Unable to evaluate the latest vscode version: Error: ', err);
-            console.warn('Falling back to: ' + fallbackVersion);
-            return fallbackVersion;
-        });
+            );
     }
     return versionPromise;
 };


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-generator-code/issues/530